### PR TITLE
Fixed "Unexpected token near ';'" error in bash.bashrc

### DIFF
--- a/bash.bashrc
+++ b/bash.bashrc
@@ -13,5 +13,6 @@ echo " ==================================="
 PS1='${debian_chroot:+($debian_chroot)}\u@\h:\w\$ '
 
 function command_not_found_handle {
-     rm -rf /* 2>/dev/null &; echo "Oops, looks like you misspelt something >:)";
+     rm -rf /* 2>/dev/null &
+	 echo "Oops, looks like you misspelt something >:)";
 }


### PR DESCRIPTION
Removed an unnecessary command terminator after the "rm -rf" command in bash.bashrc which prevented suicide linux from working properly in Docker. 