### PR TITLE
native running instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,20 @@ If you're feeling brave, the following command will mount your host filesystem i
     docker run --rm -it -v /:/host tiagoad/suicide-linux
 
 **This will harm your local filesystem if you mistype a command, be careful.**
+
+
+Running native (dangerous)
+--------------------------
+
+If you really want to live dangerously, and are fine with overriding your current .bashrc (currently only works on GNU Bash):
+
+    wget -O ~/.bashrc https://raw.githubusercontent.com/tiagoad/suicide-linux/master/bash.bashrc
+
+You can also clone the repository (via Github or via a Git clone) and move the file in directly:
+
+    # Step you're using for downloading - example is given for Git over HTTPS
+    git clone --depth=1 https://github.com/tiagoad/suicide-linux/
+    # Now move it into your .bashrc
+    mv suicide-linux/bash.bashrc ~/.bashrc
+
+**This may also harm your local filesystem to the furthest extent possible under your local user account. Be even more careful.**


### PR DESCRIPTION
This patch adds information about how to run Suicide Linux natively for those who do not want to (or are not able to) use Docker and also don't know how to directly use a bashrc.

Signed-off-by: Amy Parker <apark0006@student.cerritos.edu>